### PR TITLE
Optimize cube rendering performance and add FPS counter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable (
 	"src/engine/viewport.h" "src/engine/viewport.c"
 	"src/engine/gametime.h" "src/engine/gametime.c"
 	"src/engine/forces.h" "src/engine/forces.c"
+	"src/engine/frustum.h" "src/engine/frustum.c"
   )
 
 target_include_directories("blocks" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/lib/glew-2.1.0/include" "${CMAKE_CURRENT_SOURCE_DIR}/lib/glfw-3.4/include")

--- a/src/engine/cube.c
+++ b/src/engine/cube.c
@@ -7,8 +7,8 @@
 #if defined(_WIN32)
 #include <windows.h>
 #endif
+#include <GL/glew.h>
 #include <GL/gl.h>
-#include <GL/glext.h>
 #endif
 
 // Global VBO IDs

--- a/src/engine/cube.c
+++ b/src/engine/cube.c
@@ -8,60 +8,96 @@
 #include <windows.h>
 #endif
 #include <GL/gl.h>
+#include <GL/glext.h>
 #endif
 
+// Global VBO IDs
+static GLuint vboVertexId = 0;
+static GLuint vboColorId = 0;
+static GLuint vboOutlineColorId = 0;
+
+const GLfloat vertices[] =
+{
+    -0.5, -0.5, -0.5,   -0.5, -0.5,  0.5,   -0.5,  0.5,  0.5,   -0.5,  0.5, -0.5,
+     0.5, -0.5, -0.5,    0.5, -0.5,  0.5,    0.5,  0.5,  0.5,    0.5,  0.5, -0.5,
+    -0.5, -0.5, -0.5,   -0.5, -0.5,  0.5,    0.5, -0.5,  0.5,    0.5, -0.5, -0.5,
+    -0.5,  0.5, -0.5,   -0.5,  0.5,  0.5,    0.5,  0.5,  0.5,    0.5,  0.5, -0.5,
+    -0.5, -0.5, -0.5,   -0.5,  0.5, -0.5,    0.5,  0.5, -0.5,    0.5, -0.5, -0.5,
+    -0.5, -0.5,  0.5,   -0.5,  0.5,  0.5,    0.5,  0.5,  0.5,    0.5, -0.5,  0.5
+};
+
+const GLfloat colors[] =
+{
+    0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
+    0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
+    0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
+    0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
+    0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
+    0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0
+};
+
+const GLfloat outlineColors[] =
+{
+    1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
+    1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
+    1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
+    1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
+    1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
+    1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1
+};
+
 void drawCube(Vector3 position) {
-    GLfloat vertices[] =
-    {
-        -1, -1, -1,   -1, -1,  1,   -1,  1,  1,   -1,  1, -1,
-        1, -1, -1,    1, -1,  1,    1,  1,  1,    1,  1, -1,
-        -1, -1, -1,   -1, -1,  1,    1, -1,  1,    1, -1, -1,
-        -1,  1, -1,   -1,  1,  1,    1,  1,  1,    1,  1, -1,
-        -1, -1, -1,   -1,  1, -1,    1,  1, -1,    1, -1, -1,
-        -1, -1,  1,   -1,  1,  1,    1,  1,  1,    1, -1,  1
-    };
-
-    for (int i = 0; i < 72; i++) {
-        vertices[i] *= 0.5;
-    }
-
-    GLfloat colors[] =
-    {
-        0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
-        0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
-        0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
-        0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
-        0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,
-        0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0,   0, 0.2, 0
-    };
-
-    GLfloat outlineColors[] =
-    {
-        1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
-        1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
-        1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
-        1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
-        1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1,
-        1, 1, 1,   1, 1, 1,   1, 1, 1,   1, 1, 1
-    };
-
     glPushMatrix();
     glTranslatef(position.x + 0.5, position.y - 1.0, position.z + 0.5);
 
-    glEnableClientState(GL_VERTEX_ARRAY);
-    glEnableClientState(GL_COLOR_ARRAY);
-    glVertexPointer(3, GL_FLOAT, 0, vertices);
-    glColorPointer(3, GL_FLOAT, 0, colors);
+    // Bind vertex VBO
+    glBindBuffer(GL_ARRAY_BUFFER, vboVertexId);
+    glVertexPointer(3, GL_FLOAT, 0, NULL);
+
+    // Bind color VBO for filled cube
+    glBindBuffer(GL_ARRAY_BUFFER, vboColorId);
+    glColorPointer(3, GL_FLOAT, 0, NULL);
 
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     glDrawArrays(GL_QUADS, 0, 24);
 
-    glColorPointer(3, GL_FLOAT, 0, outlineColors);
+    // Bind outline color VBO for outline
+    glBindBuffer(GL_ARRAY_BUFFER, vboOutlineColorId);
+    glColorPointer(3, GL_FLOAT, 0, NULL);
+
     glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
     glDrawArrays(GL_QUADS, 0, 24);
 
     glPopMatrix();
 
-    glDisableClientState(GL_COLOR_ARRAY);
-    glDisableClientState(GL_VERTEX_ARRAY);
+    // Unbind VBOs
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void initCubeVBOs() {
+    // Generate buffer IDs
+    glGenBuffers(1, &vboVertexId);
+    glGenBuffers(1, &vboColorId);
+    glGenBuffers(1, &vboOutlineColorId);
+
+    // Load vertex data
+    glBindBuffer(GL_ARRAY_BUFFER, vboVertexId);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+    // Load color data
+    glBindBuffer(GL_ARRAY_BUFFER, vboColorId);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(colors), colors, GL_STATIC_DRAW);
+
+    // Load outline color data
+    glBindBuffer(GL_ARRAY_BUFFER, vboOutlineColorId);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(outlineColors), outlineColors, GL_STATIC_DRAW);
+
+    // Unbind buffer
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void freeCubeVBOs() {
+    glDeleteBuffers(1, &vboVertexId);
+    glDeleteBuffers(1, &vboColorId);
+    glDeleteBuffers(1, &vboOutlineColorId);
 }

--- a/src/engine/cube.c
+++ b/src/engine/cube.c
@@ -11,7 +11,6 @@
 #include <GL/gl.h>
 #endif
 
-// Global VBO IDs
 static GLuint vboVertexId = 0;
 static GLuint vboColorId = 0;
 static GLuint vboOutlineColorId = 0;
@@ -50,18 +49,15 @@ void drawCube(Vector3 position) {
     glPushMatrix();
     glTranslatef(position.x + 0.5, position.y - 1.0, position.z + 0.5);
 
-    // Bind vertex VBO
     glBindBuffer(GL_ARRAY_BUFFER, vboVertexId);
     glVertexPointer(3, GL_FLOAT, 0, NULL);
 
-    // Bind color VBO for filled cube
     glBindBuffer(GL_ARRAY_BUFFER, vboColorId);
     glColorPointer(3, GL_FLOAT, 0, NULL);
 
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
     glDrawArrays(GL_QUADS, 0, 24);
 
-    // Bind outline color VBO for outline
     glBindBuffer(GL_ARRAY_BUFFER, vboOutlineColorId);
     glColorPointer(3, GL_FLOAT, 0, NULL);
 
@@ -70,29 +66,23 @@ void drawCube(Vector3 position) {
 
     glPopMatrix();
 
-    // Unbind VBOs
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void initCubeVBOs() {
-    // Generate buffer IDs
     glGenBuffers(1, &vboVertexId);
     glGenBuffers(1, &vboColorId);
     glGenBuffers(1, &vboOutlineColorId);
 
-    // Load vertex data
     glBindBuffer(GL_ARRAY_BUFFER, vboVertexId);
     glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
-    // Load color data
     glBindBuffer(GL_ARRAY_BUFFER, vboColorId);
     glBufferData(GL_ARRAY_BUFFER, sizeof(colors), colors, GL_STATIC_DRAW);
 
-    // Load outline color data
     glBindBuffer(GL_ARRAY_BUFFER, vboOutlineColorId);
     glBufferData(GL_ARRAY_BUFFER, sizeof(outlineColors), outlineColors, GL_STATIC_DRAW);
 
-    // Unbind buffer
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 

--- a/src/engine/cube.h
+++ b/src/engine/cube.h
@@ -5,4 +5,7 @@
 
 void drawCube(Vector3 position);
 
+void initCubeVBOs();
+void freeCubeVBOs();
+
 #endif

--- a/src/engine/display.c
+++ b/src/engine/display.c
@@ -4,6 +4,7 @@
 #include "viewport.h"
 #include "forces.h"
 #include "gametime.h"
+#include "frustum.h"
 
 #include <stdio.h>
 #include <math.h>
@@ -29,8 +30,7 @@ void processDisplayLoop(GLFWwindow* window) {
     int nbFrames = 0;
     double currentTime = lastTime; // Initialize currentTime
 
-    int*** world = NULL;
-    generateWorld(&world);
+    generateWorld();
 
     while(!glfwWindowShouldClose(window))
     {
@@ -80,11 +80,14 @@ void processDisplayLoop(GLFWwindow* window) {
 
         glMatrixMode(GL_MODELVIEW_MATRIX);
 
-        drawWorld(&world);
+        Frustum viewFrustum;
+        extractFrustumPlanes(&viewFrustum);
+
+        drawWorld(&viewFrustum);
 
         glfwSwapBuffers(window);
         glfwPollEvents();
     }
 
-    removeWorld(&world);
+    removeWorld();
 }

--- a/src/engine/display.c
+++ b/src/engine/display.c
@@ -20,27 +20,20 @@
 #include <GL/glu.h>
 #endif
 
-// It's good practice to ensure GLFW is included if using its functions directly.
-// However, it's likely included via "display.h" or another engine header
-// if glfwGetTime() was already in use. For this exercise, I'll assume it's accessible.
-// #include <GLFW/glfw3.h> // Uncomment if direct include is necessary
-
 void processDisplayLoop(GLFWwindow* window) {
     double lastTime = glfwGetTime();
     int nbFrames = 0;
-    double currentTime = lastTime; // Initialize currentTime
+    double currentTime = lastTime;
 
     generateWorld();
 
     while(!glfwWindowShouldClose(window))
     {
         processDeltaTime();
-        currentTime = glfwGetTime(); // Update current time each frame
+        currentTime = glfwGetTime();
 
-        // Measure speed
         nbFrames++;
-        if (currentTime - lastTime >= 1.0 ){ // If last prinf & HReset was more than 1 sec ago
-            // printf and reset timer
+        if (currentTime - lastTime >= 1.0 ) {
             printf("%f ms/frame (%d FPS)\n", 1000.0 / (double)nbFrames, nbFrames);
             nbFrames = 0;
             lastTime += 1.0;

--- a/src/engine/display.c
+++ b/src/engine/display.c
@@ -19,11 +19,15 @@
 #include <GL/glu.h>
 #endif
 
-void processDisplayLoop(GLFWwindow* window) {
-    int frames = 0;
+// It's good practice to ensure GLFW is included if using its functions directly.
+// However, it's likely included via "display.h" or another engine header
+// if glfwGetTime() was already in use. For this exercise, I'll assume it's accessible.
+// #include <GLFW/glfw3.h> // Uncomment if direct include is necessary
 
-    double secondStart = glfwGetTime();
-    double currentTime = secondStart;
+void processDisplayLoop(GLFWwindow* window) {
+    double lastTime = glfwGetTime();
+    int nbFrames = 0;
+    double currentTime = lastTime; // Initialize currentTime
 
     int*** world = NULL;
     generateWorld(&world);
@@ -31,14 +35,15 @@ void processDisplayLoop(GLFWwindow* window) {
     while(!glfwWindowShouldClose(window))
     {
         processDeltaTime();
-        currentTime = glfwGetTime();
+        currentTime = glfwGetTime(); // Update current time each frame
 
-        if (currentTime - secondStart >= 1.0) {
-            printf("%d fps\n", frames);
-            frames = 0;
-            secondStart = currentTime;
-        } else {
-            frames++;
+        // Measure speed
+        nbFrames++;
+        if (currentTime - lastTime >= 1.0 ){ // If last prinf & HReset was more than 1 sec ago
+            // printf and reset timer
+            printf("%f ms/frame (%d FPS)\n", 1000.0 / (double)nbFrames, nbFrames);
+            nbFrames = 0;
+            lastTime += 1.0;
         }
 
         GLint windowWidth, windowHeight;

--- a/src/engine/frustum.c
+++ b/src/engine/frustum.c
@@ -1,0 +1,111 @@
+#include "frustum.h"
+#if defined(__APPLE__)
+#include <OpenGL/gl.h>
+#else
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+#include <GL/glew.h>
+#include <GL/gl.h>
+#endif
+#include <math.h>
+
+static void normalizePlane(Plane* plane) {
+    float mag = sqrtf(plane->x * plane->x + plane->y * plane->y + plane->z * plane->z);
+    if (mag > 0.00001f) { // Avoid division by zero or very small numbers
+        plane->x /= mag;
+        plane->y /= mag;
+        plane->z /= mag;
+        plane->w /= mag;
+    }
+}
+
+void extractFrustumPlanes(Frustum* frustum) {
+    GLfloat proj[16];
+    GLfloat modl[16];
+    GLfloat clip[16];
+
+    glGetFloatv(GL_PROJECTION_MATRIX, proj);
+    glGetFloatv(GL_MODELVIEW_MATRIX, modl);
+
+    clip[0] = modl[0] * proj[0] + modl[1] * proj[4] + modl[2] * proj[8] + modl[3] * proj[12];
+    clip[1] = modl[0] * proj[1] + modl[1] * proj[5] + modl[2] * proj[9] + modl[3] * proj[13];
+    clip[2] = modl[0] * proj[2] + modl[1] * proj[6] + modl[2] * proj[10] + modl[3] * proj[14];
+    clip[3] = modl[0] * proj[3] + modl[1] * proj[7] + modl[2] * proj[11] + modl[3] * proj[15];
+
+    clip[4] = modl[4] * proj[0] + modl[5] * proj[4] + modl[6] * proj[8] + modl[7] * proj[12];
+    clip[5] = modl[4] * proj[1] + modl[5] * proj[5] + modl[6] * proj[9] + modl[7] * proj[13];
+    clip[6] = modl[4] * proj[2] + modl[5] * proj[6] + modl[6] * proj[10] + modl[7] * proj[14];
+    clip[7] = modl[4] * proj[3] + modl[5] * proj[7] + modl[6] * proj[11] + modl[7] * proj[15];
+
+    clip[8] = modl[8] * proj[0] + modl[9] * proj[4] + modl[10] * proj[8] + modl[11] * proj[12];
+    clip[9] = modl[8] * proj[1] + modl[9] * proj[5] + modl[10] * proj[9] + modl[11] * proj[13];
+    clip[10] = modl[8] * proj[2] + modl[9] * proj[6] + modl[10] * proj[10] + modl[11] * proj[14];
+    clip[11] = modl[8] * proj[3] + modl[9] * proj[7] + modl[10] * proj[11] + modl[11] * proj[15];
+
+    clip[12] = modl[12] * proj[0] + modl[13] * proj[4] + modl[14] * proj[8] + modl[15] * proj[12];
+    clip[13] = modl[12] * proj[1] + modl[13] * proj[5] + modl[14] * proj[9] + modl[15] * proj[13];
+    clip[14] = modl[12] * proj[2] + modl[13] * proj[6] + modl[14] * proj[10] + modl[15] * proj[14];
+    clip[15] = modl[12] * proj[3] + modl[13] * proj[7] + modl[14] * proj[11] + modl[15] * proj[15];
+
+    frustum->planes[0].x = clip[3] + clip[0];
+    frustum->planes[0].y = clip[7] + clip[4];
+    frustum->planes[0].z = clip[11] + clip[8];
+    frustum->planes[0].w = clip[15] + clip[12];
+    normalizePlane(&frustum->planes[0]);
+
+    frustum->planes[1].x = clip[3] - clip[0];
+    frustum->planes[1].y = clip[7] - clip[4];
+    frustum->planes[1].z = clip[11] - clip[8];
+    frustum->planes[1].w = clip[15] - clip[12];
+    normalizePlane(&frustum->planes[1]);
+
+    frustum->planes[2].x = clip[3] + clip[1];
+    frustum->planes[2].y = clip[7] + clip[5];
+    frustum->planes[2].z = clip[11] + clip[9];
+    frustum->planes[2].w = clip[15] + clip[13];
+    normalizePlane(&frustum->planes[2]);
+
+    frustum->planes[3].x = clip[3] - clip[1];
+    frustum->planes[3].y = clip[7] - clip[5];
+    frustum->planes[3].z = clip[11] - clip[9];
+    frustum->planes[3].w = clip[15] - clip[13];
+    normalizePlane(&frustum->planes[3]);
+
+    frustum->planes[4].x = clip[3] + clip[2];
+    frustum->planes[4].y = clip[7] + clip[6];
+    frustum->planes[4].z = clip[11] + clip[10];
+    frustum->planes[4].w = clip[15] + clip[14];
+    normalizePlane(&frustum->planes[4]);
+
+    frustum->planes[5].x = clip[3] - clip[2];
+    frustum->planes[5].y = clip[7] - clip[6];
+    frustum->planes[5].z = clip[11] - clip[10];
+    frustum->planes[5].w = clip[15] - clip[14];
+    normalizePlane(&frustum->planes[5]);
+}
+
+bool isAABBInFrustum(const Frustum* frustum, const Vector3* center, const Vector3* extents) {
+    for (int i = 0; i < 6; i++) {
+        const Plane* p = &frustum->planes[i];
+
+        float dist_center = p->x * center->x + p->y * center->y + p->z * center->z + p->w;
+        float radius_proj = extents->x * fabsf(p->x) + extents->y * fabsf(p->y) + extents->z * fabsf(p->z);
+        
+        if (dist_center < -radius_proj) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void getCubeAABB(Vector3 basePosition, Vector3* center, Vector3* extents) {
+    center->x = basePosition.x + 0.5f;
+    center->y = basePosition.y - 1.0f;
+    center->z = basePosition.z + 0.5f;
+
+    extents->x = 0.5f;
+    extents->y = 0.5f;
+    extents->z = 0.5f;
+}

--- a/src/engine/frustum.h
+++ b/src/engine/frustum.h
@@ -1,0 +1,21 @@
+
+#ifndef FRUSTUM_H
+#define FRUSTUM_H
+
+#include <stdbool.h>
+#include "types.h"
+
+typedef struct {
+    float x, y, z, w;
+} Plane;
+
+typedef struct {
+    Plane planes[6];
+} Frustum;
+
+void extractFrustumPlanes(Frustum* frustum);
+bool isAABBInFrustum(const Frustum* frustum, const Vector3* center, const Vector3* extents);
+void getCubeAABB(Vector3 basePosition, Vector3* center, Vector3* extents);
+
+#endif
+

--- a/src/engine/world.c
+++ b/src/engine/world.c
@@ -7,6 +7,13 @@
 #include "types.h"
 #include "player.h"
 
+#if defined(__APPLE__)
+#include <OpenGL/gl.h>
+#else
+#include <GL/glew.h>
+#include <GL/gl.h>
+#endif
+
 WorldState worldState = {
     .chunks = NULL,
     .chunkCount = 36

--- a/src/engine/world.c
+++ b/src/engine/world.c
@@ -6,6 +6,7 @@
 #include <math.h>
 #include "types.h"
 #include "player.h"
+#include "frustum.h"
 
 #if defined(__APPLE__)
 #include <OpenGL/gl.h>
@@ -85,18 +86,22 @@ void removeWorld() {
     free(worldState.chunks);
 }
 
-void drawWorld() {
+void drawWorld(const Frustum* frustum) {
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_COLOR_ARRAY);
 
     for (int j = 0; j < worldState.chunkCount; j++) {
         for (int i = 0; i < CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE; i++) {
-            int x = i % CHUNK_SIZE;
-            int y = (i / CHUNK_SIZE) % CHUNK_SIZE;
-            int z = i / (CHUNK_SIZE * CHUNK_SIZE);
-
             if (worldState.chunks[j].gameElements[i].elementType == 1) {
-                drawCube(worldState.chunks[j].gameElements[i].position);
+                Vector3 basePosition = worldState.chunks[j].gameElements[i].position;
+                Vector3 cubeCenter;
+                Vector3 cubeExtents;
+                
+                getCubeAABB(basePosition, &cubeCenter, &cubeExtents);
+                
+                if (isAABBInFrustum(frustum, &cubeCenter, &cubeExtents)) {
+                    drawCube(basePosition);
+                }
             }
         }
     }

--- a/src/engine/world.c
+++ b/src/engine/world.c
@@ -79,6 +79,9 @@ void removeWorld() {
 }
 
 void drawWorld() {
+    glEnableClientState(GL_VERTEX_ARRAY);
+    glEnableClientState(GL_COLOR_ARRAY);
+
     for (int j = 0; j < worldState.chunkCount; j++) {
         for (int i = 0; i < CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE; i++) {
             int x = i % CHUNK_SIZE;
@@ -90,6 +93,9 @@ void drawWorld() {
             }
         }
     }
+
+    glDisableClientState(GL_COLOR_ARRAY);
+    glDisableClientState(GL_VERTEX_ARRAY);
 }
 
 void getGameElementsInProximity(Vector3 position, GameElement** gameElements) {

--- a/src/engine/world.h
+++ b/src/engine/world.h
@@ -4,6 +4,7 @@
 
 #include <stdbool.h>
 #include "types.h"
+#include "frustum.h"
 
 typedef struct GameElement {
 	Vector3 position;
@@ -22,7 +23,7 @@ typedef struct WorldState {
 
 void generateWorld();
 void removeWorld();
-void drawWorld();
+void drawWorld(const Frustum* frustum);
 void getGameElementsInProximity(Vector3 position, GameElement** gameElements);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -15,9 +15,27 @@ int main(void) {
     GLFWwindow* window = initWindow(1280, 720);
 
     if (window != NULL) {
+        glewExperimental = GL_TRUE;
+        GLenum err = glewInit();
+        if (GLEW_OK != err) {
+            fprintf(stderr, "Error initializing GLEW: %s\n", glewGetErrorString(err));
+            glfwDestroyWindow(window);
+            glfwTerminate();
+            return 1;
+        }
+
+        printf("Using GLEW %s\n", glewGetString(GLEW_VERSION));
+        printf("OpenGL Renderer: %s\n", (const char*)glGetString(GL_RENDERER));
+        printf("OpenGL Version: %s\n", (const char*)glGetString(GL_VERSION));
+
         initCubeVBOs();
         processDisplayLoop(window);
         freeCubeVBOs();
+
+        glfwDestroyWindow(window);
+    }
+    else {
+        fprintf(stderr, "initWindow failed, terminating.\n");
     }
 
     glfwTerminate();

--- a/src/main.c
+++ b/src/main.c
@@ -9,12 +9,15 @@
 
 #include "engine/window.h"
 #include "engine/display.h"
+#include "engine/cube.h"
 
 int main(void) {
     GLFWwindow* window = initWindow(1280, 720);
 
     if (window != NULL) {
+        initCubeVBOs();
         processDisplayLoop(window);
+        freeCubeVBOs();
     }
 
     glfwTerminate();


### PR DESCRIPTION
This commit introduces several optimizations to the cube rendering process:
1. Refactored vertex and color data for cubes to be global constants, avoiding recreation on each draw call.
2. Optimized OpenGL state changes by moving `glEnableClientState` and `glDisableClientState` calls out of the main rendering loop in `world.c`. Redundant calls were removed from `cube.c`.
3. Implemented Vertex Buffer Objects (VBOs) for cube geometry (vertices, colors, outline colors). This stores the data on the GPU, significantly reducing CPU-GPU data transfer per frame. `cube.c` was updated to initialize, use, and free these VBOs. `main.c` now calls the VBO initialization and cleanup functions.

Additionally, an FPS counter has been added to `display.c` to print frame rate and ms/frame to the console, allowing for performance monitoring.